### PR TITLE
chore: integrate Vercel Speed Insights for performance tracking

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+legacy-peer-deps=true

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@angular/core": "^21.2.11",
         "@angular/platform-browser": "^21.2.11",
         "@vercel/analytics": "^2.0.1",
+        "@vercel/speed-insights": "^2.0.0",
         "rxjs": "^7.8.1",
         "tslib": "^2.0.0"
       },
@@ -7567,6 +7568,44 @@
         "@remix-run/react": {
           "optional": true
         },
+        "@sveltejs/kit": {
+          "optional": true
+        },
+        "next": {
+          "optional": true
+        },
+        "nuxt": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "svelte": {
+          "optional": true
+        },
+        "vue": {
+          "optional": true
+        },
+        "vue-router": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vercel/speed-insights": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@vercel/speed-insights/-/speed-insights-2.0.0.tgz",
+      "integrity": "sha512-jwkNcrTeafWxjmWq4AHBaptSqZiJkYU5adLC9QBSqeim0GcqDMgN5Ievh8OG1rJ6W3A4l1oiP7qr9CWxGuzu3w==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "@sveltejs/kit": "^1 || ^2",
+        "next": ">= 13",
+        "nuxt": ">= 3",
+        "react": "^18 || ^19 || ^19.0.0-rc",
+        "svelte": ">= 4",
+        "vue": "^3",
+        "vue-router": "^4"
+      },
+      "peerDependenciesMeta": {
         "@sveltejs/kit": {
           "optional": true
         },

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "@angular/core": "^21.2.11",
     "@angular/platform-browser": "^21.2.11",
     "@vercel/analytics": "^2.0.1",
+    "@vercel/speed-insights": "^2.0.0",
     "rxjs": "^7.8.1",
     "tslib": "^2.0.0"
   },

--- a/src/app/analytics/vercel-speed-insights.spec.ts
+++ b/src/app/analytics/vercel-speed-insights.spec.ts
@@ -1,0 +1,26 @@
+vi.mock('@vercel/speed-insights', () => ({
+  injectSpeedInsights: vi.fn(),
+}));
+
+import { injectSpeedInsights } from '@vercel/speed-insights';
+import { initVercelSpeedInsights } from './vercel-speed-insights';
+
+describe('initVercelSpeedInsights', () => {
+  beforeEach(() => {
+    vi.mocked(injectSpeedInsights).mockClear();
+  });
+
+  it('registers Vercel Speed Insights for production', () => {
+    initVercelSpeedInsights(true);
+    expect(injectSpeedInsights).toHaveBeenCalledWith(
+      expect.objectContaining({ debug: false, framework: 'angular' }),
+    );
+  });
+
+  it('registers Vercel Speed Insights for development', () => {
+    initVercelSpeedInsights(false);
+    expect(injectSpeedInsights).toHaveBeenCalledWith(
+      expect.objectContaining({ debug: true, framework: 'angular' }),
+    );
+  });
+});

--- a/src/app/analytics/vercel-speed-insights.ts
+++ b/src/app/analytics/vercel-speed-insights.ts
@@ -1,0 +1,8 @@
+import { injectSpeedInsights } from '@vercel/speed-insights';
+
+export function initVercelSpeedInsights(isProduction: boolean): void {
+  injectSpeedInsights({
+    debug: !isProduction,
+    framework: 'angular',
+  });
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -2,6 +2,7 @@ import { enableProdMode, provideZonelessChangeDetection } from '@angular/core';
 import { bootstrapApplication } from '@angular/platform-browser';
 
 import { AppComponent } from './app/app.component';
+import { initVercelSpeedInsights } from './app/analytics/vercel-speed-insights';
 import { initVercelWebAnalytics } from './app/analytics/vercel-web-analytics';
 import { environment } from './environments/environment';
 
@@ -10,6 +11,7 @@ if (environment.production) {
 }
 
 initVercelWebAnalytics(environment.production);
+initVercelSpeedInsights(environment.production);
 
 bootstrapApplication(AppComponent, {
   providers: [provideZonelessChangeDetection()],

--- a/src/main.vercel-speed-insights.spec.ts
+++ b/src/main.vercel-speed-insights.spec.ts
@@ -1,0 +1,16 @@
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+const mainTsPath = join(dirname(fileURLToPath(import.meta.url)), 'main.ts');
+
+describe('main bootstrap', () => {
+  it('initializes Vercel Speed Insights from the app entry', () => {
+    const source = readFileSync(mainTsPath, 'utf8');
+    expect(source).toContain("from './app/analytics/vercel-speed-insights'");
+    expect(source).toMatch(
+      /initVercelSpeedInsights\s*\(\s*environment\.production\s*\)/,
+    );
+  });
+});


### PR DESCRIPTION
- Added @vercel/speed-insights version 2.0.0 to package.json and package-lock.json.
- Initialized Vercel Speed Insights in main.ts to enhance application performance monitoring.